### PR TITLE
Correct typos in names of hash-related jets

### DIFF
--- a/docs/documentation/jets.md
+++ b/docs/documentation/jets.md
@@ -352,19 +352,19 @@ Here is a complete list of the available jets in the Elements Simplicity integra
     | <div style="width:22em">Jet</div> | Description |
     | ----------------------------------- | ----------- |
     | `sha_256_block(u256, u256, u256) -> u256` | Update the given 256-bit midstate by running the SHA256 block compression function, using the given 512-bit block. |
-    | `sha_256_ctx8_add1(Ctx8, u8) -> Ctx8` | Add 1 byte to the SHA256 hash engine. |
-    | `sha_256_ctx8_add2(Ctx8, u16) -> Ctx8` | Add 2 bytes to the SHA256 hash engine. |
-    | `sha_256_ctx8_add4(Ctx8, u32) -> Ctx8` | Add 4 bytes to the SHA256 hash engine. |
-    | `sha_256_ctx8_add8(Ctx8, u64) -> Ctx8` | Add 8 bytes to the SHA256 hash engine. |
-    | `sha_256_ctx8_add16(Ctx8, u128) -> Ctx8` | Add 16 bytes to the SHA256 hash engine. |
-    | `sha_256_ctx8_add32(Ctx8, u256) -> Ctx8` | Add 32 bytes to the SHA256 hash engine. |
-    | `sha_256_ctx8_add64(Ctx8, array(u8, 64)) -> Ctx8` | Add 64 bytes to the SHA256 hash engine. |
-    | `sha_256_ctx8_add128(Ctx8, array(u8, 128)) -> Ctx8` | Add 128 bytes to the SHA256 hash engine. |
-    | `sha_256_ctx8_add256(Ctx8, array(u8, 256)) -> Ctx8` | Add 256 bytes to the SHA256 hash engine. |
-    | `sha_256_ctx8_add512(Ctx8, array(u8, 512)) -> Ctx8` | Add 512 bytes to the SHA256 hash engine. |
-    | `sha_256_ctx8_add_buffer511(Ctx8, [u8; 512]) -> Ctx8` | Add a list of less than 512 bytes to the SHA256 hash engine. |
-    | `sha_256_ctx8_finalize(Ctx8) -> u256` | Produce a hash from the current state of the SHA256 hash engine. |
-    | `sha_256_ctx8_init() -> Ctx8` | Initialize a default SHA256 hash engine. |
+    | `sha_256_ctx_8_add_1(Ctx8, u8) -> Ctx8` | Add 1 byte to the SHA256 hash engine. |
+    | `sha_256_ctx_8_add_2(Ctx8, u16) -> Ctx8` | Add 2 bytes to the SHA256 hash engine. |
+    | `sha_256_ctx_8_add_4(Ctx8, u32) -> Ctx8` | Add 4 bytes to the SHA256 hash engine. |
+    | `sha_256_ctx_8_add_8(Ctx8, u64) -> Ctx8` | Add 8 bytes to the SHA256 hash engine. |
+    | `sha_256_ctx_8_add_16(Ctx8, u128) -> Ctx8` | Add 16 bytes to the SHA256 hash engine. |
+    | `sha_256_ctx_8_add_32(Ctx8, u256) -> Ctx8` | Add 32 bytes to the SHA256 hash engine. |
+    | `sha_256_ctx_8_add_64(Ctx8, array(u8, 64)) -> Ctx8` | Add 64 bytes to the SHA256 hash engine. |
+    | `sha_256_ctx_8_add_128(Ctx8, array(u8, 128)) -> Ctx8` | Add 128 bytes to the SHA256 hash engine. |
+    | `sha_256_ctx_8_add_256(Ctx8, array(u8, 256)) -> Ctx8` | Add 256 bytes to the SHA256 hash engine. |
+    | `sha_256_ctx_8_add_512(Ctx8, array(u8, 512)) -> Ctx8` | Add 512 bytes to the SHA256 hash engine. |
+    | `sha_256_ctx_8_add_buffer_511(Ctx8, [u8; 512]) -> Ctx8` | Add a list of less than 512 bytes to the SHA256 hash engine. |
+    | `sha_256_ctx_8_finalize(Ctx8) -> u256` | Produce a hash from the current state of the SHA256 hash engine. |
+    | `sha_256_ctx_8_init() -> Ctx8` | Initialize a default SHA256 hash engine. |
     | `sha_256_iv() -> u256` | Return the SHA256 initial value. |
 
 ### Elliptic curve functions

--- a/jets.json
+++ b/jets.json
@@ -2458,7 +2458,7 @@
     },
     {
       "haskell_name": "Sha256Ctx8Add1",
-      "simplicityhl_name": "sha_256_ctx8_add1",
+      "simplicityhl_name": "sha_256_ctx_8_add_1",
       "section": "Hash functions",
       "input_type": "Ctx8, u8",
       "output_type": "Ctx8",
@@ -2466,7 +2466,7 @@
     },
     {
       "haskell_name": "Sha256Ctx8Add2",
-      "simplicityhl_name": "sha_256_ctx8_add2",
+      "simplicityhl_name": "sha_256_ctx_8_add_2",
       "section": "Hash functions",
       "input_type": "Ctx8, u16",
       "output_type": "Ctx8",
@@ -2474,7 +2474,7 @@
     },
     {
       "haskell_name": "Sha256Ctx8Add4",
-      "simplicityhl_name": "sha_256_ctx8_add4",
+      "simplicityhl_name": "sha_256_ctx_8_add_4",
       "section": "Hash functions",
       "input_type": "Ctx8, u32",
       "output_type": "Ctx8",
@@ -2482,7 +2482,7 @@
     },
     {
       "haskell_name": "Sha256Ctx8Add8",
-      "simplicityhl_name": "sha_256_ctx8_add8",
+      "simplicityhl_name": "sha_256_ctx_8_add_8",
       "section": "Hash functions",
       "input_type": "Ctx8, u64",
       "output_type": "Ctx8",
@@ -2490,7 +2490,7 @@
     },
     {
       "haskell_name": "Sha256Ctx8Add16",
-      "simplicityhl_name": "sha_256_ctx8_add16",
+      "simplicityhl_name": "sha_256_ctx_8_add_16",
       "section": "Hash functions",
       "input_type": "Ctx8, u128",
       "output_type": "Ctx8",
@@ -2498,7 +2498,7 @@
     },
     {
       "haskell_name": "Sha256Ctx8Add32",
-      "simplicityhl_name": "sha_256_ctx8_add32",
+      "simplicityhl_name": "sha_256_ctx_8_add_32",
       "section": "Hash functions",
       "input_type": "Ctx8, u256",
       "output_type": "Ctx8",
@@ -2506,7 +2506,7 @@
     },
     {
       "haskell_name": "Sha256Ctx8Add64",
-      "simplicityhl_name": "sha_256_ctx8_add64",
+      "simplicityhl_name": "sha_256_ctx_8_add_64",
       "section": "Hash functions",
       "input_type": "Ctx8, array(u8, 64)",
       "output_type": "Ctx8",
@@ -2514,7 +2514,7 @@
     },
     {
       "haskell_name": "Sha256Ctx8Add128",
-      "simplicityhl_name": "sha_256_ctx8_add128",
+      "simplicityhl_name": "sha_256_ctx_8_add_128",
       "section": "Hash functions",
       "input_type": "Ctx8, array(u8, 128)",
       "output_type": "Ctx8",
@@ -2522,7 +2522,7 @@
     },
     {
       "haskell_name": "Sha256Ctx8Add256",
-      "simplicityhl_name": "sha_256_ctx8_add256",
+      "simplicityhl_name": "sha_256_ctx_8_add_256",
       "section": "Hash functions",
       "input_type": "Ctx8, array(u8, 256)",
       "output_type": "Ctx8",
@@ -2530,7 +2530,7 @@
     },
     {
       "haskell_name": "Sha256Ctx8Add512",
-      "simplicityhl_name": "sha_256_ctx8_add512",
+      "simplicityhl_name": "sha_256_ctx_8_add_512",
       "section": "Hash functions",
       "input_type": "Ctx8, array(u8, 512)",
       "output_type": "Ctx8",
@@ -2538,7 +2538,7 @@
     },
     {
       "haskell_name": "Sha256Ctx8AddBuffer511",
-      "simplicityhl_name": "sha_256_ctx8_add_buffer511",
+      "simplicityhl_name": "sha_256_ctx_8_add_buffer_511",
       "section": "Hash functions",
       "input_type": "Ctx8, [u8; 512]",
       "output_type": "Ctx8",
@@ -2546,7 +2546,7 @@
     },
     {
       "haskell_name": "Sha256Ctx8Finalize",
-      "simplicityhl_name": "sha_256_ctx8_finalize",
+      "simplicityhl_name": "sha_256_ctx_8_finalize",
       "section": "Hash functions",
       "input_type": "Ctx8",
       "output_type": "u256",
@@ -2554,7 +2554,7 @@
     },
     {
       "haskell_name": "Sha256Ctx8Init",
-      "simplicityhl_name": "sha_256_ctx8_init",
+      "simplicityhl_name": "sha_256_ctx_8_init",
       "section": "Hash functions",
       "input_type": "",
       "output_type": "Ctx8",


### PR DESCRIPTION
There was misspelled jet names in documentation and `jets.json` file. Source: https://github.com/BlockstreamResearch/rust-simplicity/blob/d28440bc0c6be333aa84fa441844541c14dbb563/src/jet/init/elements.rs#L8806-L8818